### PR TITLE
Bring haddock heading onto one line.

### DIFF
--- a/src/Graphics/GLUtil/ShaderProgram.hs
+++ b/src/Graphics/GLUtil/ShaderProgram.hs
@@ -4,8 +4,7 @@
 module Graphics.GLUtil.ShaderProgram 
   (-- * The ShaderProgram type
    ShaderProgram(..), 
-   -- * Simple shader programs utilizing a vertex shader and a
-   -- fragment shader
+   -- * Simple shader programs utilizing a vertex shader and a fragment shader
    simpleShaderProgram, simpleShaderProgramWith, simpleShaderExplicit, 
    -- * Explicit shader loading
    loadShaderProgramWith,


### PR DESCRIPTION
Haddock [does not render](http://hackage.haskell.org/packages/archive/GLUtil/0.7/doc/html/Graphics-GLUtil-ShaderProgram.html) the second line of this header.

The [docs](http://www.haskell.org/haddock/doc/html/ch03s04.html) make no mention of what should happen with multi-line headers.
