### PR TITLE
Do not print shader info log if it contains only \NUL

### DIFF
--- a/src/Graphics/GLUtil/Shaders.hs
+++ b/src/Graphics/GLUtil/Shaders.hs
@@ -28,7 +28,7 @@ loadShaderBS filePath st src = do
   printError
   ok <- get (compileStatus shader)
   infoLog <- get (shaderInfoLog shader)
-  unless (null infoLog)
+  unless (null infoLog || infoLog == "\NUL")
          (mapM_ putStrLn
                 ["Shader info log for '" ++ filePath ++ "':", infoLog, ""])
   unless ok $ do


### PR DESCRIPTION
This patch fixes #15.
