### PR TITLE
Changed `panRad` to post-multiply the new transformation.

### DIFF
--- a/src/Graphics/GLUtil/Camera3D.hs
+++ b/src/Graphics/GLUtil/Camera3D.hs
@@ -29,7 +29,7 @@ data Camera a = Camera { forward     :: V3 a
 -- radians. Panning is about the world's up-axis as captured by the
 -- initial camera state (e.g. the positive Y axis for 'fpsCamera').
 panRad :: (Epsilon a, RealFloat a) => a -> Camera a -> Camera a
-panRad theta c = c { orientation = r * orientation c }
+panRad theta c = c { orientation = orientation c * r }
   where r = axisAngle (upward c) theta
 
 -- | Pan a camera view (turn side-to-side) by an angle given in


### PR DESCRIPTION
Now panning is relative to the current camera orientation, and not relative to the global coordinates, i.e. after `roll`ing 90 degrees to the right, panning right is rotates the camera down in the global coordinates. This is consistent with the current behaviour of `tilt` and `roll`.

This solves issue #18, assuming this is the behaviour desired. The other option would be to modify `tilt` and `roll` to also be relative to the global coordinates.