### PR TITLE
Don't use hpp as the preprocessor on Windows.

### DIFF
--- a/GLUtil.cabal
+++ b/GLUtil.cabal
@@ -57,7 +57,7 @@ Library
                        OpenGL >= 3 && < 3.1,
                        transformers >= 0.3,
                        vector >= 0.7
-  if impl(ghc >= 7.10.1)
+  if (impl(ghc >= 7.10.1) && (!os(windows)))
     Build-depends:     hpp >= 0.3.1 && < 0.5
     GHC-Options:       -pgmPhpp -optP--cpp -optP-P
   else


### PR DESCRIPTION
Building `master` on Windows with GHC 8.2.1 yields this on my Windows 10 machine:

```
C:\Users\Travis\sources\GLUtil\src\Graphics\GLUtil\ShaderProgram.hs:1:1: error:
    File name does not match module name:
    Saw: `Main'
    Expected: `Graphics.GLUtil.ShaderProgram'
  |
1 | {-# LANGUAGE CPP #-}
  | ^

--  While building package GLUtil-0.9.1.1 using:
      C:\sr\setup-exe-cache\x86_64-windows\Cabal-simple_Z6RU0evB_2.0.0.2_ghc-8.2.1.exe --builddir=.stack-work\dist\e53504d9 build lib:GLUtil --ghc-options " -ddump-hi -ddump-to-file"
    Process exited with code: ExitFailure 1
```

The issue seems to be due to `hpp`. I'd be happy to help figure out what's going on with `hpp` on Windows (I don't have this problem on my Linux machines), but in the meantime using `cpphs` on Windows makes the package buildable.