### PR TITLE
Add support for GHC 8.6.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,9 @@ matrix:
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.2], sources: [hvr-ghc]}}
     - compiler: "ghc-8.4.1"
-      env: GHCHEAD=true
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.6.2"
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.6.2], sources: [hvr-ghc]}}
 
   # allow_failures:
   #   - compiler: "ghc-8.4.1"

--- a/GLUtil.cabal
+++ b/GLUtil.cabal
@@ -61,6 +61,6 @@ Library
     Build-tool-depends: cpphs:cpphs
     GHC-Options:        -pgmPcpphs -optP--cpp -optP--hashes
 
-  GHC-Options:         -Odph -Wall
+  GHC-Options:         -O2 -Wall
   HS-Source-Dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
`-Odph` flag was finally dropped in GHC 8.6.

This flag used to simply be an alias for `-O2
-fmax-simplifier-iterations=20 -fsimplifier-phases=3`. I'm re-adding
-O2 only: if you think the additional `-f` flags were necessary (the
defaults are 4 for `max-simplifier-iterations` and 2 for
`simplifier-phases`), they can be easily re-added as well.

I also add 8.6.2 to CI and drop the unnecessary (?) GHCHEAD env var
from 8.4.1 while there.